### PR TITLE
Fix unchecked cast warnings by fiddling with generics

### DIFF
--- a/src/main/java/chopchop/model/FoodEntryBook.java
+++ b/src/main/java/chopchop/model/FoodEntryBook.java
@@ -28,7 +28,7 @@ public abstract class FoodEntryBook implements ReadOnlyFoodEntryBook {
      * Replaces the contents of the person list with {@code persons}.
      * {@code persons} must not contain duplicate persons.
      */
-    public void setFoodEntries(List<FoodEntry> entries) {
+    public void setFoodEntries(List<? extends FoodEntry> entries) {
         this.entries.setFoodEntries(entries);
     }
 

--- a/src/main/java/chopchop/model/ReadOnlyFoodEntryBook.java
+++ b/src/main/java/chopchop/model/ReadOnlyFoodEntryBook.java
@@ -5,12 +5,11 @@ import javafx.collections.ObservableList;
 /**
  * Unmodifiable view of a food entry book
  */
-public interface ReadOnlyFoodEntryBook <FoodEntry> {
+public interface ReadOnlyFoodEntryBook {
 
     /**
      * Returns an unmodifiable view of the food entry list.
      * This list will not contain any duplicate food entries.
      */
-    ObservableList<FoodEntry> getFoodEntryList();
-
+    ObservableList<? extends FoodEntry> getFoodEntryList();
 }

--- a/src/main/java/chopchop/model/UniqueFoodEntryList.java
+++ b/src/main/java/chopchop/model/UniqueFoodEntryList.java
@@ -76,7 +76,7 @@ public class UniqueFoodEntryList implements Iterable<FoodEntry> {
      * Replaces the contents of this list with {@code FoodEntries}.
      * {@code FoodEntries} must not contain duplicate FoodEntries.
      */
-    public void setFoodEntries(List<FoodEntry> entries) {
+    public void setFoodEntries(List<? extends FoodEntry> entries) {
         requireAllNonNull(entries);
         //if (!ingredientsAreUnique(entries)) {
         if (!foodEntriesAreUnique(entries)) {
@@ -113,7 +113,7 @@ public class UniqueFoodEntryList implements Iterable<FoodEntry> {
     /**
      * Returns true if {@code FoodEntries} contains only unique FoodEntries.
      */
-    private boolean ingredientsAreUnique(List<FoodEntry> ingredients) {
+    private boolean ingredientsAreUnique(List<? extends FoodEntry> ingredients) {
         for (int i = 0; i < ingredients.size() - 1; i++) {
             for (int j = i + 1; j < ingredients.size(); j++) {
                 if (ingredients.get(i).equals(ingredients.get(j))) {
@@ -127,7 +127,7 @@ public class UniqueFoodEntryList implements Iterable<FoodEntry> {
     /**
      * Returns true if {@code FoodEntries} contains only unique FoodEntries.
      */
-    private boolean recipesAreUnique(List<FoodEntry> recipes) {
+    private boolean recipesAreUnique(List<? extends FoodEntry> recipes) {
         for (int i = 0; i < recipes.size() - 1; i++) {
             for (int j = i + 1; j < recipes.size(); j++) {
                 if (recipes.get(i).equals(recipes.get(j))) {
@@ -141,7 +141,7 @@ public class UniqueFoodEntryList implements Iterable<FoodEntry> {
     /**
      * Returns true if {@code FoodEntries} contains only unique FoodEntries.
      */
-    private boolean foodEntriesAreUnique(List<FoodEntry> foodEntries) {
+    private boolean foodEntriesAreUnique(List<? extends FoodEntry> foodEntries) {
         for (int i = 0; i < foodEntries.size() - 1; i++) {
             for (int j = i + 1; j < foodEntries.size(); j++) {
                 if (foodEntries.get(i).equals(foodEntries.get(j))) {

--- a/src/main/java/chopchop/model/attributes/NameContainsKeywordsPredicate.java
+++ b/src/main/java/chopchop/model/attributes/NameContainsKeywordsPredicate.java
@@ -9,7 +9,7 @@ import chopchop.model.FoodEntry;
 /**
  * Tests that a {@code FoodEntry}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate <F extends FoodEntry> implements Predicate<F> {
+public class NameContainsKeywordsPredicate implements Predicate<FoodEntry> {
     private final List<String> keywords;
 
     public NameContainsKeywordsPredicate(List<String> keywords) {
@@ -17,7 +17,7 @@ public class NameContainsKeywordsPredicate <F extends FoodEntry> implements Pred
     }
 
     @Override
-    public boolean test(F fe) {
+    public boolean test(FoodEntry fe) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(fe.getName().fullName, keyword));
     }

--- a/src/main/java/chopchop/model/ingredient/ReadOnlyIngredientBook.java
+++ b/src/main/java/chopchop/model/ingredient/ReadOnlyIngredientBook.java
@@ -9,6 +9,7 @@ public interface ReadOnlyIngredientBook extends ReadOnlyFoodEntryBook {
      * Returns an unmodifiable view of the ingredient list.
      * This list will not contain any duplicate ingredients.
      */
+    @Override
     ObservableList<Ingredient> getFoodEntryList();
 
 }

--- a/src/main/java/chopchop/model/recipe/ReadOnlyRecipeBook.java
+++ b/src/main/java/chopchop/model/recipe/ReadOnlyRecipeBook.java
@@ -12,6 +12,6 @@ public interface ReadOnlyRecipeBook extends ReadOnlyFoodEntryBook {
      * Returns an unmodifiable view of the recipes list.
      * This list will not contain any duplicate recipes.
      */
+    @Override
     ObservableList<Recipe> getFoodEntryList();
-
 }


### PR DESCRIPTION
Remove superfluous generics from classes and use wildcards. Fixes warnings introduced in #40 