### PR TITLE
Fix target parsing for commands

### DIFF
--- a/src/main/java/chopchop/logic/commands/AddIngredientCommand.java
+++ b/src/main/java/chopchop/logic/commands/AddIngredientCommand.java
@@ -47,10 +47,6 @@ public class AddIngredientCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasIngredient(ingredient)) {
-            throw new CommandException(MESSAGE_DUPLICATE_INGREDIENT);
-        }
-
         var foo = model.findIngredientWithName(this.ingredient.getName());
         if (foo.isPresent()) {
             var existing = foo.get();

--- a/src/main/java/chopchop/logic/parser/CommandArguments.java
+++ b/src/main/java/chopchop/logic/parser/CommandArguments.java
@@ -3,7 +3,6 @@
 package chopchop.logic.parser;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
@@ -12,7 +11,6 @@ import chopchop.util.Pair;
 /**
  * A container class to hold a parsed command, holding its:
  * - name
- * - target
  * - unnamed arguments
  * - named arguments
  *
@@ -22,8 +20,7 @@ import chopchop.util.Pair;
  * Would have the following properties:
  * {@code
  *      command     = "add"
- *      target      = "ingredient"
- *      remaining   = "onions"
+ *      remaining   = "ingredient onions"
  *      arguments   = [
  *                      ("quantity", "500g"),
  *                      ("location", "fridge"),
@@ -41,7 +38,6 @@ import chopchop.util.Pair;
 public class CommandArguments {
 
     private final String command;
-    private final String target;
     private final String remaining;
     private final List<Pair<ArgName, String>> arguments;
 
@@ -52,8 +48,7 @@ public class CommandArguments {
      */
     public CommandArguments(String command) {
         this.command    = command;
-        this.target     = null;
-        this.remaining  = null;
+        this.remaining  = "";
         this.arguments  = new ArrayList<>();
     }
 
@@ -66,23 +61,7 @@ public class CommandArguments {
      */
     public CommandArguments(String command, List<Pair<ArgName, String>> arguments) {
         this.command    = command;
-        this.target     = null;
-        this.remaining  = null;
-        this.arguments  = new ArrayList<>(arguments);
-    }
-
-    /**
-     * Constructs a set of command arguments consisting of the command name, the command
-     * target, and some number of named arguments.
-     *
-     * @param command   the name of the command
-     * @param target    the command target
-     * @param arguments a map of named arguments and their values
-     */
-    public CommandArguments(String command, String target, List<Pair<ArgName, String>> arguments) {
-        this.command    = command;
-        this.target     = target;
-        this.remaining  = null;
+        this.remaining  = "";
         this.arguments  = new ArrayList<>(arguments);
     }
 
@@ -91,15 +70,12 @@ public class CommandArguments {
      * target, any remaining non-named arguments, and some number of named arguments.
      *
      * @param command   the name of the command
-     * @param target    the command target
      * @param remaining any remaining non-named arguments
      * @param arguments a map of named arguments and their values
      */
-    public CommandArguments(String command, String target, String remaining,
-        List<Pair<ArgName, String>> arguments) {
+    public CommandArguments(String command, String remaining, List<Pair<ArgName, String>> arguments) {
 
         this.command    = command;
-        this.target     = target;
         this.remaining  = remaining;
         this.arguments  = new ArrayList<>(arguments);
     }
@@ -108,12 +84,8 @@ public class CommandArguments {
         return this.command;
     }
 
-    public Optional<String> getTarget() {
-        return Optional.ofNullable(this.target);
-    }
-
-    public Optional<String> getRemaining() {
-        return Optional.ofNullable(this.remaining);
+    public String getRemaining() {
+        return this.remaining;
     }
 
     /**

--- a/src/main/java/chopchop/logic/parser/CommandParser.java
+++ b/src/main/java/chopchop/logic/parser/CommandParser.java
@@ -3,7 +3,6 @@
 package chopchop.logic.parser;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.ArrayList;
 
 import chopchop.util.Pair;
@@ -74,27 +73,7 @@ public class CommandParser {
 
         sv.bisect(x, ' ', xs);
 
-        /*
-            add recipe NAME [/ingredient INGREDIENT [/qty QTY1]...]... [/step STEP]...
-            delete recipe NAME
-            find recipe KEYWORDS [MORE_KEYWORDS]
-            list recipes
-            make RECIPE_NAME [/qty TIMES]
-
-            add ingredient NAME [/qty QUANTITY] [/expiry DATE]
-            use ingredient NAME [/qty QUANTITY]
-            find ingredient KEYWORDS [MORE_KEYWORDS]
-            list ingredients
-        */
-
         var command = x.toString().strip();
-        xs.bisect(x, ' ', xs);
-
-        var target = Optional.of(x)
-            .filter(s -> !s.isEmpty())
-            .map(StringView::toString)
-            .map(String::strip)
-            .orElse(null);
 
         xs.bisect(x, '/', xs);
         var theRest = x.toString().strip();
@@ -105,7 +84,7 @@ public class CommandParser {
         }
 
         return this.parseNamedArguments(xs)
-            .map(args -> new CommandArguments(command, target, theRest, args));
+            .map(args -> new CommandArguments(command, theRest, args));
     }
 
 

--- a/src/main/java/chopchop/logic/parser/commands/CommandTarget.java
+++ b/src/main/java/chopchop/logic/parser/commands/CommandTarget.java
@@ -1,0 +1,12 @@
+// CommandTarget.java
+
+package chopchop.logic.parser.commands;
+
+/**
+ * Just a very simple enumeration to represent the "target" of a command, which is either
+ * recipes (eg. add recipe) or ingredients (eg. add ingredient).
+ */
+public enum CommandTarget {
+    RECIPE,
+    INGREDIENT
+}

--- a/src/main/java/chopchop/util/Strings.java
+++ b/src/main/java/chopchop/util/Strings.java
@@ -23,6 +23,6 @@ public class Strings {
     public static final String COMMAND_DELETE       = "delete";
 
     // command targets
-    public static final String TARGET_RECIPE        = "recipe";
-    public static final String TARGET_INGREDIENT    = "ingredient";
+    // public static final String TARGET_RECIPE        = "recipe";
+    // public static final String TARGET_INGREDIENT    = "ingredient";
 }

--- a/src/test/java/chopchop/logic/commands/AddIngredientCommandIntTest.java
+++ b/src/test/java/chopchop/logic/commands/AddIngredientCommandIntTest.java
@@ -1,6 +1,5 @@
 package chopchop.logic.commands;
 
-import static chopchop.logic.commands.CommandTestUtil.assertCommandFailure;
 import static chopchop.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static chopchop.testutil.TypicalIngredients.getTypicalIngredientBook;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,12 +29,4 @@ public class AddIngredientCommandIntTest {
         assertCommandSuccess(new AddIngredientCommand(validIngredient), model,
             String.format(AddIngredientCommand.MESSAGE_SUCCESS, validIngredient), expectedModel);
     }
-
-    @Test
-    public void execute_duplicateIngredient_throwsCommandException() {
-        Ingredient personInList = model.getIngredientBook().getFoodEntryList().get(0);
-        assertCommandFailure(new AddIngredientCommand(personInList), model,
-            AddIngredientCommand.MESSAGE_DUPLICATE_INGREDIENT);
-    }
-
 }

--- a/src/test/java/chopchop/logic/commands/AddIngredientCommandTest.java
+++ b/src/test/java/chopchop/logic/commands/AddIngredientCommandTest.java
@@ -5,10 +5,9 @@ import java.util.Optional;
 import java.util.ArrayList;
 import java.util.NoSuchElementException;
 
-import chopchop.logic.commands.exceptions.CommandException;
-
 import chopchop.model.ModelStub;
 import chopchop.model.attributes.Name;
+import chopchop.model.attributes.units.Volume;
 
 import chopchop.model.ingredient.Ingredient;
 import chopchop.model.ingredient.IngredientBook;
@@ -43,17 +42,6 @@ public class AddIngredientCommandTest {
     }
 
     @Test
-    public void execute_duplicateIngredient_throwsCommandException() {
-        var validIngredient = new IngredientBuilder().build();
-        var addCommand = new AddIngredientCommand(validIngredient);
-        var modelStub = new ModelStubWithIngredient(validIngredient);
-
-        assertThrows(CommandException.class,
-            AddIngredientCommand.MESSAGE_DUPLICATE_INGREDIENT, () -> addCommand.execute(modelStub)
-        );
-    }
-    /*
-    @Test
     public void add_ingredients_combine() throws Exception {
         var milk1 = new IngredientBuilder().withName("milk").withQuantity(Volume.litres(0.7)).build();
         var milk2 = new IngredientBuilder().withName("MILK").withQuantity(Volume.cups(1)).build();
@@ -69,7 +57,7 @@ public class AddIngredientCommandTest {
 
         assertEquals(String.format(AddIngredientCommand.MESSAGE_COMBINED, milk3), out2);
     }
-    */
+
     @Test
     public void equals() {
         var apple = new IngredientBuilder().withName("Apple").build();


### PR DESCRIPTION
Includes `add`, `list`, `find`, and `delete`. Closes #60 