### PR TITLE
Fix #162 — Display both command output and a modal alert box when recipes/ingredients could not be loaded

### DIFF
--- a/src/main/java/chopchop/MainApp.java
+++ b/src/main/java/chopchop/MainApp.java
@@ -2,8 +2,8 @@ package chopchop;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.function.Supplier;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 import chopchop.commons.core.Config;
@@ -19,22 +19,15 @@ import chopchop.model.EntryBook;
 import chopchop.model.Model;
 import chopchop.model.ModelManager;
 import chopchop.model.ReadOnlyEntryBook;
-import chopchop.model.ReadOnlyUserPrefs;
 import chopchop.model.UsageList;
 import chopchop.model.UserPrefs;
-import chopchop.model.ingredient.Ingredient;
-import chopchop.model.recipe.Recipe;
-import chopchop.model.usage.IngredientUsage;
-import chopchop.model.usage.RecipeUsage;
 import chopchop.model.usage.Usage;
 import chopchop.model.util.SampleDataUtil;
-import chopchop.storage.IngredientBookStorage;
 import chopchop.storage.JsonIngredientBookStorage;
 import chopchop.storage.JsonIngredientUsageStorage;
 import chopchop.storage.JsonRecipeBookStorage;
 import chopchop.storage.JsonRecipeUsageStorage;
 import chopchop.storage.JsonUserPrefsStorage;
-import chopchop.storage.RecipeBookStorage;
 import chopchop.storage.Storage;
 import chopchop.storage.StorageManager;
 import chopchop.storage.UserPrefsStorage;
@@ -186,95 +179,6 @@ public class MainApp extends Application {
             return new UsageList<T>();
         }
     }
-
-
-
-
-    /**
-     * Returns a {@code ModelManager} with the data from {@code storage}'s ingredient and recipe book and
-     * {@code userPrefs}. <br>
-     * The data from the sample ingredient or recipe book will be used instead if {@code storage}'s ingredient or
-     * recipe book is not found, or an empty ingredient or recipe book will be used instead if errors occur when
-     * reading {@code storage}'s ingredient or recipe book.
-     */
-//     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-// <<<<<<< HEAD
-//         Optional<ReadOnlyEntryBook<Recipe>> recipeBookOptional;
-//         Optional<ReadOnlyEntryBook<Ingredient>> ingredientBookOptional;
-//         Optional<UsageList<RecipeUsage>> recipeUsageOptional;
-//         Optional<UsageList<IngredientUsage>> ingredientUsageOptional;
-// =======
-// >>>>>>> abdfe936... Split the loading of recipe and ingredient books
-//         ReadOnlyEntryBook<Recipe> initialRecipeData;
-//         ReadOnlyEntryBook<Ingredient> initialIngredientData;
-//         UsageList<RecipeUsage> initialRecipeUsageData;
-//         UsageList<IngredientUsage> initialIngredientUsageData;
-
-//         try {
-// <<<<<<< HEAD
-//             recipeBookOptional = storage.readRecipeBook();
-//             ingredientBookOptional = storage.readIngredientBook();
-//             recipeUsageOptional = storage.readRecipeUsages();
-//             ingredientUsageOptional = storage.readIngredientUsages();
-
-//             if (recipeBookOptional.isEmpty()) {
-//                 logger.info("Data file for recipe book not found. Will be starting with a sample RecipeBook");
-// =======
-//             var opt = storage.readRecipeBook();
-//             if (opt.isEmpty()) {
-//                 logger.info("Data file for recipe book not found; starting with sample recipes");
-// >>>>>>> abdfe936... Split the loading of recipe and ingredient books
-//             }
-
-//             initialRecipeData = opt.orElseGet(SampleDataUtil::getSampleRecipeBook);
-
-// <<<<<<< HEAD
-//             if (recipeUsageOptional.isEmpty()) {
-//                 logger.info("Data file for recipe usage list not found. Will be starting with an empty list");
-//             }
-
-//             if (ingredientUsageOptional.isEmpty()) {
-//                 logger.info("Data file for ingredient usage list not found. Will be starting with an empty list");
-//             }
-
-//             initialRecipeData = recipeBookOptional.orElseGet(SampleDataUtil::getSampleRecipeBook);
-//             initialIngredientData = ingredientBookOptional.orElseGet(SampleDataUtil::getSampleIngredientBook);
-//             initialRecipeUsageData = recipeUsageOptional.isEmpty() ? new UsageList<RecipeUsage>()
-//                                                                     : recipeUsageOptional.get();
-//             initialIngredientUsageData = ingredientUsageOptional.isEmpty() ? new UsageList<IngredientUsage>()
-//                                                                             : ingredientUsageOptional.get();
-//         } catch (DataConversionException e) {
-//             logger.warning("Data file not in the correct format. Will be starting with an empty RecipeBook and"
-//                     + " IngredientBook and their usage files");
-// =======
-//         } catch (DataConversionException e) {
-
-//             logger.warning("Recipe book was not in the correct format; starting with an empty recipe book");
-// >>>>>>> abdfe936... Split the loading of recipe and ingredient books
-//             initialRecipeData = new EntryBook<>();
-//         }
-
-
-
-//         try {
-//             var opt = storage.readIngredientBook();
-//             if (opt.isEmpty()) {
-//                 logger.info("Data file for ingredient book not found; starting with sample ingredients");
-//             }
-
-//             initialIngredientData = opt.orElseGet(SampleDataUtil::getSampleIngredientBook);
-
-//         } catch (DataConversionException e) {
-
-//             logger.warning("Ingredient book was not in the correct format; starting with an empty ingredient book");
-//             initialIngredientData = new EntryBook<>();
-//             initialRecipeUsageData = new UsageList<RecipeUsage>();
-//             initialIngredientUsageData = new UsageList<IngredientUsage>();
-//         }
-
-//         return new ModelManager(initialRecipeData, initialIngredientData, initialRecipeUsageData,
-//             initialIngredientUsageData, userPrefs);
-//     }
 
     private void initLogging(Config config) {
         LogsCenter.init(config);

--- a/src/main/java/chopchop/MainApp.java
+++ b/src/main/java/chopchop/MainApp.java
@@ -89,56 +89,84 @@ public class MainApp extends Application {
      * recipe book is not found, or an empty ingredient or recipe book will be used instead if errors occur when
      * reading {@code storage}'s ingredient or recipe book.
      */
-    private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
-        Optional<ReadOnlyEntryBook<Recipe>> recipeBookOptional;
-        Optional<ReadOnlyEntryBook<Ingredient>> ingredientBookOptional;
-        Optional<UsageList<RecipeUsage>> recipeUsageOptional;
-        Optional<UsageList<IngredientUsage>> ingredientUsageOptional;
-        ReadOnlyEntryBook<Recipe> initialRecipeData;
-        ReadOnlyEntryBook<Ingredient> initialIngredientData;
-        UsageList<RecipeUsage> initialRecipeUsageData;
-        UsageList<IngredientUsage> initialIngredientUsageData;
+//     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
+// <<<<<<< HEAD
+//         Optional<ReadOnlyEntryBook<Recipe>> recipeBookOptional;
+//         Optional<ReadOnlyEntryBook<Ingredient>> ingredientBookOptional;
+//         Optional<UsageList<RecipeUsage>> recipeUsageOptional;
+//         Optional<UsageList<IngredientUsage>> ingredientUsageOptional;
+// =======
+// >>>>>>> abdfe936... Split the loading of recipe and ingredient books
+//         ReadOnlyEntryBook<Recipe> initialRecipeData;
+//         ReadOnlyEntryBook<Ingredient> initialIngredientData;
+//         UsageList<RecipeUsage> initialRecipeUsageData;
+//         UsageList<IngredientUsage> initialIngredientUsageData;
 
-        try {
-            recipeBookOptional = storage.readRecipeBook();
-            ingredientBookOptional = storage.readIngredientBook();
-            recipeUsageOptional = storage.readRecipeUsages();
-            ingredientUsageOptional = storage.readIngredientUsages();
+//         try {
+// <<<<<<< HEAD
+//             recipeBookOptional = storage.readRecipeBook();
+//             ingredientBookOptional = storage.readIngredientBook();
+//             recipeUsageOptional = storage.readRecipeUsages();
+//             ingredientUsageOptional = storage.readIngredientUsages();
 
-            if (recipeBookOptional.isEmpty()) {
-                logger.info("Data file for recipe book not found. Will be starting with a sample RecipeBook");
-            }
+//             if (recipeBookOptional.isEmpty()) {
+//                 logger.info("Data file for recipe book not found. Will be starting with a sample RecipeBook");
+// =======
+//             var opt = storage.readRecipeBook();
+//             if (opt.isEmpty()) {
+//                 logger.info("Data file for recipe book not found; starting with sample recipes");
+// >>>>>>> abdfe936... Split the loading of recipe and ingredient books
+//             }
 
-            if (ingredientBookOptional.isEmpty()) {
-                logger.info("Data file for ingredient book not found. Will be starting with a sample IngredientBook");
-            }
+//             initialRecipeData = opt.orElseGet(SampleDataUtil::getSampleRecipeBook);
 
-            if (recipeUsageOptional.isEmpty()) {
-                logger.info("Data file for recipe usage list not found. Will be starting with an empty list");
-            }
+// <<<<<<< HEAD
+//             if (recipeUsageOptional.isEmpty()) {
+//                 logger.info("Data file for recipe usage list not found. Will be starting with an empty list");
+//             }
 
-            if (ingredientUsageOptional.isEmpty()) {
-                logger.info("Data file for ingredient usage list not found. Will be starting with an empty list");
-            }
+//             if (ingredientUsageOptional.isEmpty()) {
+//                 logger.info("Data file for ingredient usage list not found. Will be starting with an empty list");
+//             }
 
-            initialRecipeData = recipeBookOptional.orElseGet(SampleDataUtil::getSampleRecipeBook);
-            initialIngredientData = ingredientBookOptional.orElseGet(SampleDataUtil::getSampleIngredientBook);
-            initialRecipeUsageData = recipeUsageOptional.isEmpty() ? new UsageList<RecipeUsage>()
-                                                                    : recipeUsageOptional.get();
-            initialIngredientUsageData = ingredientUsageOptional.isEmpty() ? new UsageList<IngredientUsage>()
-                                                                            : ingredientUsageOptional.get();
-        } catch (DataConversionException e) {
-            logger.warning("Data file not in the correct format. Will be starting with an empty RecipeBook and"
-                    + " IngredientBook and their usage files");
-            initialRecipeData = new EntryBook<>();
-            initialIngredientData = new EntryBook<>();
-            initialRecipeUsageData = new UsageList<RecipeUsage>();
-            initialIngredientUsageData = new UsageList<IngredientUsage>();
-        }
+//             initialRecipeData = recipeBookOptional.orElseGet(SampleDataUtil::getSampleRecipeBook);
+//             initialIngredientData = ingredientBookOptional.orElseGet(SampleDataUtil::getSampleIngredientBook);
+//             initialRecipeUsageData = recipeUsageOptional.isEmpty() ? new UsageList<RecipeUsage>()
+//                                                                     : recipeUsageOptional.get();
+//             initialIngredientUsageData = ingredientUsageOptional.isEmpty() ? new UsageList<IngredientUsage>()
+//                                                                             : ingredientUsageOptional.get();
+//         } catch (DataConversionException e) {
+//             logger.warning("Data file not in the correct format. Will be starting with an empty RecipeBook and"
+//                     + " IngredientBook and their usage files");
+// =======
+//         } catch (DataConversionException e) {
 
-        return new ModelManager(initialRecipeData, initialIngredientData, initialRecipeUsageData,
-            initialIngredientUsageData, userPrefs);
-    }
+//             logger.warning("Recipe book was not in the correct format; starting with an empty recipe book");
+// >>>>>>> abdfe936... Split the loading of recipe and ingredient books
+//             initialRecipeData = new EntryBook<>();
+//         }
+
+
+
+//         try {
+//             var opt = storage.readIngredientBook();
+//             if (opt.isEmpty()) {
+//                 logger.info("Data file for ingredient book not found; starting with sample ingredients");
+//             }
+
+//             initialIngredientData = opt.orElseGet(SampleDataUtil::getSampleIngredientBook);
+
+//         } catch (DataConversionException e) {
+
+//             logger.warning("Ingredient book was not in the correct format; starting with an empty ingredient book");
+//             initialIngredientData = new EntryBook<>();
+//             initialRecipeUsageData = new UsageList<RecipeUsage>();
+//             initialIngredientUsageData = new UsageList<IngredientUsage>();
+//         }
+
+//         return new ModelManager(initialRecipeData, initialIngredientData, initialRecipeUsageData,
+//             initialIngredientUsageData, userPrefs);
+//     }
 
     private void initLogging(Config config) {
         LogsCenter.init(config);

--- a/src/main/java/chopchop/model/Model.java
+++ b/src/main/java/chopchop/model/Model.java
@@ -158,6 +158,13 @@ public interface Model {
     /** Returns the UsageList of ingredient */
     UsageList<IngredientUsage> getIngredientUsageList();
 
+
+    /** Sets the RecipeUsageList */
+    void setRecipeUsageList(UsageList<RecipeUsage> list);
+
+    /** Sets the IngredientUsageList */
+    void setIngredientUsageList(UsageList<IngredientUsage> list);
+
     void addRecipeUsage(Recipe recipe);
 
     void removeRecipeUsage(Recipe recipe);

--- a/src/main/java/chopchop/model/ModelManager.java
+++ b/src/main/java/chopchop/model/ModelManager.java
@@ -228,7 +228,7 @@ public class ModelManager implements Model {
     }
 
     /**
-     * Returns the ReadOnlyIngredientBook
+     * Returns the RecipeUsageList
      */
     @Override
     public UsageList<RecipeUsage> getRecipeUsageList() {
@@ -236,11 +236,27 @@ public class ModelManager implements Model {
     }
 
     /**
-     * Returns the ReadOnlyIngredientBook
+     * Returns the IngredientUsageList
      */
     @Override
     public UsageList<IngredientUsage> getIngredientUsageList() {
         return this.ingredientUsageList;
+    }
+
+    /**
+     * Sets the RecipeUsageList
+     */
+    @Override
+    public void setRecipeUsageList(UsageList<RecipeUsage> list) {
+        this.recipeUsageList.setAll(list);
+    }
+
+    /**
+     * Sets the IngredientUsageList
+     */
+    @Override
+    public void setIngredientUsageList(UsageList<IngredientUsage> list) {
+        this.ingredientUsageList.setAll(list);
     }
 
     @Override

--- a/src/main/java/chopchop/model/UsageList.java
+++ b/src/main/java/chopchop/model/UsageList.java
@@ -32,6 +32,13 @@ public class UsageList<T extends Usage> {
     }
 
     /**
+     * Replaces the contents of the usage list with {@code usages}.
+     */
+    public void setAll(UsageList<T> usages) {
+        this.usages.setAll(usages.usages);
+    }
+
+    /**
      * Adds to the stack.
      */
     public void add(T item) {

--- a/src/main/java/chopchop/ui/DisplayController.java
+++ b/src/main/java/chopchop/ui/DisplayController.java
@@ -77,6 +77,9 @@ public class DisplayController extends UiPart<Region> {
                 resetButtons();
             }
         });
+
+        resetButtons();
+
         if (!logic.getFilteredRecipeList().isEmpty()) {
             displayRecipeList();
         } else if (!logic.getFilteredIngredientList().isEmpty()) {

--- a/src/main/java/chopchop/ui/MainWindow.java
+++ b/src/main/java/chopchop/ui/MainWindow.java
@@ -165,6 +165,11 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.show();
     }
 
+    void showCommandOutput(String text, boolean isError) {
+        this.commandOutput.setFeedbackToUser(text, isError);
+    }
+
+
     /**
      * Closes the application.
      */

--- a/src/main/java/chopchop/ui/Ui.java
+++ b/src/main/java/chopchop/ui/Ui.java
@@ -1,5 +1,6 @@
 package chopchop.ui;
 
+import javafx.scene.control.Alert.AlertType;
 import javafx.stage.Stage;
 
 /**
@@ -7,7 +8,18 @@ import javafx.stage.Stage;
  */
 public interface Ui {
 
-    /** Starts the UI (and the App).  */
+    /**
+     * Starts the UI (and the App).
+     */
     void start(Stage primaryStage);
 
+    /**
+     * Displays a modal dialog box
+     */
+    void displayModalDialog(AlertType alertType, String title, String header, String body);
+
+    /**
+     * Displays text in the command output box.
+     */
+    void showCommandOutput(String text, boolean isError);
 }

--- a/src/main/java/chopchop/ui/UiManager.java
+++ b/src/main/java/chopchop/ui/UiManager.java
@@ -55,9 +55,17 @@ public class UiManager implements Ui {
         return new Image(MainApp.class.getResourceAsStream(imagePath));
     }
 
-    void showAlertDialogAndWait(AlertType type, String title, String headerText, String contentText) {
+    @Override
+    public void showCommandOutput(String text, boolean isError) {
+        this.mainWindow.showCommandOutput(text, isError);
+    }
+
+
+    @Override
+    public void displayModalDialog(AlertType type, String title, String headerText, String contentText) {
         showAlertDialogAndWait(mainWindow.getPrimaryStage(), type, title, headerText, contentText);
     }
+
 
     /**
      * Shows an alert dialog on {@code owner} with the given parameters.
@@ -81,7 +89,8 @@ public class UiManager implements Ui {
      */
     private void showFatalErrorDialogAndShutdown(String title, Throwable e) {
         logger.severe(title + " " + e.getMessage() + StringUtil.getDetails(e));
-        showAlertDialogAndWait(AlertType.ERROR, title, e.getMessage(), e.toString());
+
+        displayModalDialog(AlertType.ERROR, title, e.getMessage(), e.toString());
         Platform.exit();
         System.exit(1);
     }

--- a/src/test/java/chopchop/model/ModelStub.java
+++ b/src/test/java/chopchop/model/ModelStub.java
@@ -160,6 +160,16 @@ public abstract class ModelStub implements Model {
     }
 
     @Override
+    public void setRecipeUsageList(UsageList<RecipeUsage> usages) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setIngredientUsageList(UsageList<IngredientUsage> usages) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void addRecipeUsage(Recipe recipe) {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
required changing the load order of the `Model` to come *AFTER* the `start()` is called in the `MainApp`, but I think that's fine.

Closes #162 