### PR TITLE
Allow item names to start with `#` as long as they don't parse as an ItemReference

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -79,6 +79,22 @@ For a more in-depth look at how ChopChop handles quantities, see [this section](
 A recipe consists of a list of used ingredients (and their quantities), as well as a list of steps.
 
 
+### 3.3. Name Constraints
+Recipe and ingredient names have the same constraints, of which there is only one — they cannot consist <i>only</i> of a `#` followed by digits, to diambiguate them from numbered references (for the tech savvy, the regular expression is `#[0-9]+`).
+
+Here are some examples of names that are valid and invalid:
+
+| name   | valid      |
+|--------|------------|
+| #1     | <b>no</b>  |
+| #1234  | <b>no</b>  |
+| #      | <b>yes</b> |
+| #asdf  | <b>yes</b> |
+| #1a    | <b>yes</b> |
+| #1 abc | <b>yes</b> |
+
+
+
 --------------------------------
 ## 4. Navigating the User Interface
 
@@ -111,10 +127,10 @@ Figure 1.3: <i>The Ingredient View Panel of ChopChop.</i>
 </div>
 
 <a name="CommandBox"></a>
-### 4.1 Command Box 
+### 4.1 Command Box
 ChopChop does your bidding by listening to your commands — the `Command Box` is where you type your textual commands.
 After typing your commands, press <kbd>enter</kbd> to input the command.
- 
+
 To learn about the commands you can perform, check out our [command summary](#CommandSummary) for a quick overview or our [commands](#Commands) for a detailed -.
 If you have yet to check out ChopChop's [tab completion](#TabCompletion) section, do drop by to learn this handy feature!
 
@@ -182,13 +198,13 @@ Figure 1.4: <i>The Recipe Display Panel of ChopChop.</i>
 
 <a name="RecipeName"></a>
 ### 4.10 Recipe Name and Tags
-ChopChop displays the name of the recipe, and the tags associated with it in this area. 
+ChopChop displays the name of the recipe, and the tags associated with it in this area.
 
 
 
 <a name="RecipeIngredients"></a>
 ### 4.11 Recipe Ingredients
-ChopChop displays the ingredients you need in the recipe here. The format of the display is the `Ingredient`, follow by the `(Quantity)`. 
+ChopChop displays the ingredients you need in the recipe here. The format of the display is the `Ingredient`, follow by the `(Quantity)`.
 
 
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -92,6 +92,7 @@ Here are some examples of names that are valid and invalid:
 | #asdf  | <b>yes</b> |
 | #1a    | <b>yes</b> |
 | #1 abc | <b>yes</b> |
+| #12 34 | <b>yes</b> |
 
 
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -84,15 +84,15 @@ Recipe and ingredient names have the same constraints, of which there is only on
 
 Here are some examples of names that are valid and invalid:
 
-| name   | valid      |
-|--------|------------|
-| #1     | <b>no</b>  |
-| #1234  | <b>no</b>  |
-| #      | <b>yes</b> |
-| #asdf  | <b>yes</b> |
-| #1a    | <b>yes</b> |
-| #1 abc | <b>yes</b> |
-| #12 34 | <b>yes</b> |
+| name     | valid      |
+|----------|------------|
+| `#1`     | <b>no</b>  |
+| `#1234`  | <b>no</b>  |
+| `#`      | <b>yes</b> |
+| `#asdf`  | <b>yes</b> |
+| `#1a`    | <b>yes</b> |
+| `#1 abc` | <b>yes</b> |
+| `#12 34` | <b>yes</b> |
 
 
 

--- a/src/main/java/chopchop/commons/util/Result.java
+++ b/src/main/java/chopchop/commons/util/Result.java
@@ -139,6 +139,38 @@ public class Result<T> extends Either<String, T> {
     }
 
     /**
+     * Similar to {@code then()}, but it also takes in a supplier to retrive a value in
+     * the event this result is an error. This is •NOT* equivalent to {@code x.then(...).orElseGet(..)},
+     * since the result of {@code then()} might return an error. It is equivalent to the following
+     * imperative code:
+     * {@code
+     * var x = computeResult();
+     * if (x.isError()) {
+     *     return orElse.get();
+     * } else {
+     *     return fn.apply(x.getValue());
+     * }
+     * }
+     *
+     * @param fn     the function to bind; it should return a Result.
+     * @param orElse the supplier of a Result in the event {@code this} was an error.
+     * @return       the new result
+     */
+    public <R> Result<R> thenOrElseGet(Function<? super T, ? extends Result<? extends R>> fn,
+        Supplier<? extends Result<? extends R>> orElse) {
+
+        if (this.hasValue()) {
+            @SuppressWarnings("unchecked")
+            var ret = (Result<R>) fn.apply(this.getValue());
+            return ret;
+        } else {
+            @SuppressWarnings("unchecked")
+            var ret = (Result<R>) orElse.get();
+            return ret;
+        }
+    }
+
+    /**
      * If the Result contains a value, return it, otherwise return {@code other}.
      *
      * @param other the alternative value to use

--- a/src/main/java/chopchop/logic/parser/ItemReference.java
+++ b/src/main/java/chopchop/logic/parser/ItemReference.java
@@ -101,13 +101,13 @@ public class ItemReference {
             return new StringView(input)
                 .drop(1)
                 .parseInt()
-                .then(i -> {
+                .thenOrElseGet(i -> {
                     if (i <= 0) {
                         return Result.error("Invalid index (cannot be zero or negative)");
                     } else {
                         return Result.of(ItemReference.ofOneIndex(i));
                     }
-                });
+                }, () -> Result.of(ItemReference.ofName(input)));
         } else {
             return Result.of(ItemReference.ofName(input));
         }

--- a/src/main/java/chopchop/logic/parser/commands/AddCommandParser.java
+++ b/src/main/java/chopchop/logic/parser/commands/AddCommandParser.java
@@ -16,7 +16,6 @@ import chopchop.model.attributes.Quantity;
 import chopchop.model.attributes.ExpiryDate;
 import chopchop.model.ingredient.IngredientReference;
 import chopchop.logic.parser.CommandArguments;
-import chopchop.logic.parser.ItemReference;
 import chopchop.logic.commands.Command;
 import chopchop.logic.commands.AddRecipeCommand;
 import chopchop.logic.commands.AddIngredientCommand;

--- a/src/main/java/chopchop/logic/parser/commands/AddCommandParser.java
+++ b/src/main/java/chopchop/logic/parser/commands/AddCommandParser.java
@@ -16,6 +16,7 @@ import chopchop.model.attributes.Quantity;
 import chopchop.model.attributes.ExpiryDate;
 import chopchop.model.ingredient.IngredientReference;
 import chopchop.logic.parser.CommandArguments;
+import chopchop.logic.parser.ItemReference;
 import chopchop.logic.commands.Command;
 import chopchop.logic.commands.AddRecipeCommand;
 import chopchop.logic.commands.AddIngredientCommand;
@@ -50,12 +51,18 @@ public class AddCommandParser {
                     return Result.error("Recipe or ingredient name cannot be empty");
                 }
 
+                // check whether the name can be parsed as an indexed ItemReference.
+                var name = target.snd().strip();
+                if (name.matches("#[0-9]+")) {
+                    return Result.error("Item name cannot start with a '#' and consist of only numbers");
+                }
+
                 switch (target.fst()) {
                 case RECIPE:
-                    return parseAddRecipeCommand(target.snd().strip(), args);
+                    return parseAddRecipeCommand(name, args);
 
                 case INGREDIENT:
-                    return parseAddIngredientCommand(target.snd().strip(), args);
+                    return parseAddIngredientCommand(name, args);
 
                 default:
                     return Result.error("Can only add recipes or ingredients ('%s' invalid)", target.fst());

--- a/src/test/java/chopchop/commons/util/ResultTest.java
+++ b/src/test/java/chopchop/commons/util/ResultTest.java
@@ -79,8 +79,14 @@ public class ResultTest {
             throw new RuntimeException("");
         }));
 
-
         r1.perform(x -> {});
+
+
+        var a = r1.thenOrElseGet(x -> Result.of(x + x), () -> Result.error("owo"));
+        var b = e1.thenOrElseGet(x -> Result.of(x + x), () -> Result.error("uwu"));
+
+        assertEquals(Result.of(2468), a);
+        assertEquals(Result.error("uwu"), b);
     }
 
     @Test

--- a/src/test/java/chopchop/logic/parser/ItemReferenceTest.java
+++ b/src/test/java/chopchop/logic/parser/ItemReferenceTest.java
@@ -20,10 +20,10 @@ public class ItemReferenceTest {
         var oi = ItemReference.ofOneIndex(4);
         var nm = ItemReference.ofName("owo");
 
-        assertEquals(ItemReference.parse(""), Result.error("Empty input"));
-        assertEquals(ItemReference.parse("#"), Result.error("Couldn't parse integer: For input string: \"\""));
-        assertEquals(ItemReference.parse("#0"), Result.error("Invalid index (cannot be zero or negative)"));
-        assertEquals(ItemReference.parse("#-30"), Result.error("Invalid index (cannot be zero or negative)"));
+        assertEquals(Result.error("Empty input"), ItemReference.parse(""));
+        assertEquals(Result.of(ItemReference.ofName("#")), ItemReference.parse("#"));
+        assertEquals(Result.error("Invalid index (cannot be zero or negative)"), ItemReference.parse("#0"));
+        assertEquals(Result.error("Invalid index (cannot be zero or negative)"), ItemReference.parse("#-30"));
 
         assertEquals(0, ItemReference.ofZeroIndex(0).getZeroIndex());
         assertEquals(3, ItemReference.ofZeroIndex(3).getZeroIndex());

--- a/src/test/java/chopchop/logic/parser/commands/AddCommandParserTest.java
+++ b/src/test/java/chopchop/logic/parser/commands/AddCommandParserTest.java
@@ -23,6 +23,7 @@ public class AddCommandParserTest {
         cases.put("add recipe f /ingredient x /ingredient",                             false);
         cases.put("add recipe f /ingredient x /ingredient y /qty zzz",                  false);
         cases.put("add recipe f /qty 700",                                              false);
+        cases.put("add recipe #123",                                                    false);
 
         cases.put("add ingredient",                                                     false);
         cases.put("add ingredient f /name",                                             false);
@@ -34,6 +35,9 @@ public class AddCommandParserTest {
         cases.put("add ingredient f /qty x y /qty zzz",                                 false);
         cases.put("add ingredient f /expiry",                                           false);
         cases.put("add ingredient f /expiry /expiry",                                   false);
+
+        cases.put("add recipe #123 a",                                                  true);
+        cases.put("add recipe #123 123",                                                true);
 
         cases.forEach((k, v) -> {
             assertEquals(v, parser.parse(k).hasValue());


### PR DESCRIPTION
Closes #211 