### PR TITLE
More issue closing

### DIFF
--- a/src/main/java/chopchop/logic/autocomplete/AutoCompleter.java
+++ b/src/main/java/chopchop/logic/autocomplete/AutoCompleter.java
@@ -718,8 +718,7 @@ public class AutoCompleter {
             // all commands that take a target will take ingredients, except MAKE, EDIT, and VIEW.
             return commandRequiresTarget(command)
                 && !command.equals(Strings.COMMAND_VIEW)
-                && !command.equals(Strings.COMMAND_MAKE)
-                && !command.equals(Strings.COMMAND_EDIT);
+                && !command.equals(Strings.COMMAND_MAKE);
         } else {
 
             // only list accepts recommendations.

--- a/src/main/java/chopchop/logic/autocomplete/AutoCompleter.java
+++ b/src/main/java/chopchop/logic/autocomplete/AutoCompleter.java
@@ -330,6 +330,8 @@ public class AutoCompleter {
         } else if (cmd.equals(Strings.COMMAND_EDIT)) {
             if (tgt.equals(CommandTarget.RECIPE.toString())) {
                 return completeEditRecipeArguments(args, partial, orig);
+            } else if (tgt.equals(CommandTarget.INGREDIENT.toString())) {
+                return completeEditIngredientArguments(args, partial, orig);
             }
         } else if (cmd.equals(Strings.COMMAND_DELETE)) {
             if (tgt.equals(CommandTarget.INGREDIENT.toString())) {
@@ -426,7 +428,11 @@ public class AutoCompleter {
         .orElse(orig);
     }
 
-
+    private String completeEditIngredientArguments(CommandArguments args, String partial, String orig) {
+        return tryCompletionUsing(getArgNames(Strings.ARG_TAG),
+            orig, partial, /* appending: */ ":")
+        .orElse(orig);
+    }
 
 
 

--- a/src/main/java/chopchop/logic/commands/EditIngredientCommand.java
+++ b/src/main/java/chopchop/logic/commands/EditIngredientCommand.java
@@ -1,0 +1,128 @@
+package chopchop.logic.commands;
+
+import static chopchop.commons.util.Enforce.enforceContains;
+import static chopchop.commons.util.Enforce.enforceNonNull;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import chopchop.commons.util.Result;
+import chopchop.logic.edit.EditOperationType;
+import chopchop.logic.edit.IngredientEditDescriptor;
+import chopchop.logic.edit.TagEditDescriptor;
+import chopchop.logic.history.HistoryManager;
+import chopchop.logic.parser.ItemReference;
+import chopchop.model.Model;
+import chopchop.model.attributes.Tag;
+import chopchop.model.ingredient.Ingredient;
+
+/**
+ * Edits an ingredient identified using it's displayed index or name from the recipe book.
+ */
+public class EditIngredientCommand extends Command implements Undoable {
+    private final ItemReference item;
+    private final IngredientEditDescriptor ingredientEditDescriptor;
+    private Ingredient ingredient;
+    private Ingredient editedIngredient;
+
+    /**
+     * Constructs a command that edits the given ingredient item.
+     */
+    public EditIngredientCommand(ItemReference item, IngredientEditDescriptor ingredientEditDescriptor) {
+        enforceNonNull(item, ingredientEditDescriptor);
+
+        this.item = item;
+        this.ingredientEditDescriptor = ingredientEditDescriptor;
+    }
+
+
+    @Override
+    public CommandResult execute(Model model, HistoryManager historyManager) {
+        enforceNonNull(model);
+
+        var res = resolveIngredientReference(this.item, model);
+        if (res.isError()) {
+            return CommandResult.error(res.getError());
+        }
+
+        this.ingredient = res.getValue();
+
+        var red = this.ingredientEditDescriptor;
+        if (red.getTagEdits().isEmpty()) {
+            return CommandResult.message("No edits provided; ingredient '%s' was not modified",
+                this.ingredient.getName());
+        }
+
+        var newTags = performTagEdits(red.getTagEdits());
+
+        var foo = Result.firstError(newTags);
+        if (foo.isPresent()) {
+            return CommandResult.error(foo.get());
+        }
+
+        this.editedIngredient = new Ingredient(this.ingredient.getName(),
+            this.ingredient.getIngredientSets(),
+            newTags.getValue());
+
+        model.setIngredient(this.ingredient, this.editedIngredient);
+        return CommandResult.message("Edited ingredient '%s'", this.ingredient.getName()
+        ).showingIngredientList();
+    }
+
+    private Result<Set<Tag>> performTagEdits(List<TagEditDescriptor> edits) {
+
+        var tags = new HashSet<>(this.ingredient.getTags());
+
+        for (var edit : edits) {
+
+            var tagName = edit.getTagName();
+
+            enforceContains(edit.getEditType(), EditOperationType.ADD, EditOperationType.DELETE);
+
+            if (edit.getEditType() == EditOperationType.ADD) {
+
+                if (!tags.add(new Tag(tagName))) {
+                    return Result.error("Ingredient '%s' already has tag '%s'", this.ingredient.getName(),
+                            tagName);
+                }
+
+            } else if (edit.getEditType() == EditOperationType.DELETE) {
+
+                var opt = tags.stream().filter(t -> t.equals(tagName)).findFirst();
+                if (opt.isEmpty()) {
+                    return Result.error("Ingredient '%s' does not have tag '%s'",
+                        this.ingredient.getName(), tagName);
+                }
+
+                tags.remove(opt.get());
+
+            }
+        }
+
+        return Result.of(tags);
+    }
+
+
+    @Override
+    public CommandResult undo(Model model) {
+        enforceNonNull(model);
+
+        model.setIngredient(this.editedIngredient, this.ingredient);
+        return CommandResult.message("Undo: un-edited ingredient '%s'", this.ingredient.getName())
+            .showingIngredientList();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("EditIngredientCommand(%s)", this.item);
+    }
+
+    public static String getCommandString() {
+        return "edit ingredient";
+    }
+
+    public static String getCommandHelp() {
+        return "Edits an existing ingredient";
+    }
+}

--- a/src/main/java/chopchop/logic/commands/EditIngredientCommand.java
+++ b/src/main/java/chopchop/logic/commands/EditIngredientCommand.java
@@ -18,7 +18,7 @@ import chopchop.model.attributes.Tag;
 import chopchop.model.ingredient.Ingredient;
 
 /**
- * Edits an ingredient identified using it's displayed index or name from the recipe book.
+ * Edits an ingredient identified using it's displayed index or name from the ingredient book.
  */
 public class EditIngredientCommand extends Command implements Undoable {
     private final ItemReference item;
@@ -66,8 +66,8 @@ public class EditIngredientCommand extends Command implements Undoable {
             newTags.getValue());
 
         model.setIngredient(this.ingredient, this.editedIngredient);
-        return CommandResult.message("Edited ingredient '%s'", this.ingredient.getName()
-        ).showingIngredientList();
+        return CommandResult.message("Edited ingredient '%s'", this.ingredient.getName())
+            .showingIngredientList();
     }
 
     private Result<Set<Tag>> performTagEdits(List<TagEditDescriptor> edits) {

--- a/src/main/java/chopchop/logic/commands/EditIngredientCommand.java
+++ b/src/main/java/chopchop/logic/commands/EditIngredientCommand.java
@@ -48,13 +48,13 @@ public class EditIngredientCommand extends Command implements Undoable {
 
         this.ingredient = res.getValue();
 
-        var red = this.ingredientEditDescriptor;
-        if (red.getTagEdits().isEmpty()) {
+        var ied = this.ingredientEditDescriptor;
+        if (ied.getTagEdits().isEmpty()) {
             return CommandResult.message("No edits provided; ingredient '%s' was not modified",
                 this.ingredient.getName());
         }
 
-        var newTags = performTagEdits(red.getTagEdits());
+        var newTags = performTagEdits(ied.getTagEdits());
 
         var foo = Result.firstError(newTags);
         if (foo.isPresent()) {

--- a/src/main/java/chopchop/logic/commands/EditRecipeCommand.java
+++ b/src/main/java/chopchop/logic/commands/EditRecipeCommand.java
@@ -13,7 +13,7 @@ import java.util.function.BiFunction;
 
 import chopchop.commons.util.Result;
 import chopchop.logic.edit.EditOperationType;
-import chopchop.logic.edit.IngredientEditDescriptor;
+import chopchop.logic.edit.IngredientRefEditDescriptor;
 import chopchop.logic.edit.RecipeEditDescriptor;
 import chopchop.logic.edit.StepEditDescriptor;
 import chopchop.logic.edit.TagEditDescriptor;
@@ -97,7 +97,7 @@ public class EditRecipeCommand extends Command implements Undoable {
 
 
 
-    private Result<List<IngredientReference>> performIngredientEdits(List<IngredientEditDescriptor> edits) {
+    private Result<List<IngredientReference>> performIngredientEdits(List<IngredientRefEditDescriptor> edits) {
 
         // this is a reference.
         var ingredients = new ArrayList<>(this.recipe.getIngredients());

--- a/src/main/java/chopchop/logic/commands/EditRecipeCommand.java
+++ b/src/main/java/chopchop/logic/commands/EditRecipeCommand.java
@@ -226,8 +226,10 @@ public class EditRecipeCommand extends Command implements Undoable {
 
             if (edit.getEditType() == EditOperationType.ADD) {
 
-                // it's a Set<Tag>, so we don't need to check for dupes.
-                tags.add(new Tag(tagName));
+                if (!tags.add(new Tag(tagName))) {
+                    return Result.error("Recipe '%s' already has tag '%s'", this.recipe.getName(),
+                            tagName);
+                }
 
             } else if (edit.getEditType() == EditOperationType.DELETE) {
 

--- a/src/main/java/chopchop/logic/commands/HelpCommand.java
+++ b/src/main/java/chopchop/logic/commands/HelpCommand.java
@@ -59,7 +59,7 @@ public class HelpCommand extends Command {
         var ret = CommandResult.message("%s: %s", cmdStr, cmdHelp);
 
         if (!ugSection.endsWith("Dummy")) {
-            return ret.appending("see the", /* newline: */ true)
+            return ret.appending("See the", /* newline: */ true)
                 .appendingLink("User Guide", Strings.USER_GUIDE_BASE_URL + "#" + ugSection,
                     /* newline: */ false);
         } else {
@@ -236,7 +236,7 @@ public class HelpCommand extends Command {
             return "edit";
         }
         public static String getCommandHelp() {
-            return "Edits an item; see 'edit recipe'";
+            return "Edits an item; see 'edit recipe' or 'edit ingredient'";
         }
     }
 

--- a/src/main/java/chopchop/logic/edit/IngredientEditDescriptor.java
+++ b/src/main/java/chopchop/logic/edit/IngredientEditDescriptor.java
@@ -1,0 +1,35 @@
+package chopchop.logic.edit;
+
+import java.util.List;
+import java.util.Objects;
+
+public class IngredientEditDescriptor {
+
+    private final List<TagEditDescriptor> tagEdits;
+
+    /**
+     * Creates a IngredientEditDescriptor to edit an ingredient.
+     *
+     * @param tagEdits          the list of edit descriptors for tags
+     */
+    public IngredientEditDescriptor(List<TagEditDescriptor> tagEdits) {
+        this.tagEdits = tagEdits;
+    }
+
+    public List<TagEditDescriptor> getTagEdits() {
+        return this.tagEdits;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (!(obj instanceof IngredientEditDescriptor)) {
+            return false;
+        } else {
+            var other = (IngredientEditDescriptor) obj;
+
+            return Objects.equals(this.tagEdits, other.tagEdits);
+        }
+    }
+}

--- a/src/main/java/chopchop/logic/edit/IngredientRefEditDescriptor.java
+++ b/src/main/java/chopchop/logic/edit/IngredientRefEditDescriptor.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 import chopchop.model.attributes.Quantity;
 
-public class IngredientEditDescriptor extends EditDescriptor {
+public class IngredientRefEditDescriptor extends EditDescriptor {
 
     private final Optional<Quantity> ingredientQuantity;
     private final String ingredientName;
@@ -23,7 +23,7 @@ public class IngredientEditDescriptor extends EditDescriptor {
      * @param name     the name of the ingredient to edit
      * @param qty      the new quantity of the ingredient; should only be present iff type is EDIT or ADD
      */
-    public IngredientEditDescriptor(EditOperationType editType, String name, Optional<Quantity> qty) {
+    public IngredientRefEditDescriptor(EditOperationType editType, String name, Optional<Quantity> qty) {
 
         super(editType);
 
@@ -52,10 +52,10 @@ public class IngredientEditDescriptor extends EditDescriptor {
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
-        } else if (!(obj instanceof IngredientEditDescriptor)) {
+        } else if (!(obj instanceof IngredientRefEditDescriptor)) {
             return false;
         } else {
-            var other = (IngredientEditDescriptor) obj;
+            var other = (IngredientRefEditDescriptor) obj;
             return this.getEditType() == other.getEditType()
                 && this.ingredientQuantity.equals(other.ingredientQuantity)
                 && this.ingredientName.equalsIgnoreCase(other.ingredientName);

--- a/src/main/java/chopchop/logic/edit/RecipeEditDescriptor.java
+++ b/src/main/java/chopchop/logic/edit/RecipeEditDescriptor.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public class RecipeEditDescriptor {
 
-    private final List<IngredientEditDescriptor> ingredientEdits;
+    private final List<IngredientRefEditDescriptor> ingredientEdits;
     private final List<StepEditDescriptor> stepEdits;
     private final List<TagEditDescriptor> tagEdits;
     private final Optional<String> nameEdit;
@@ -21,7 +21,7 @@ public class RecipeEditDescriptor {
      * @param tagEdits          the list of edit descriptors for tags
      * @param nameEdit          the edited name (if present)
      */
-    public RecipeEditDescriptor(Optional<String> nameEdit, List<IngredientEditDescriptor> ingredientEdits,
+    public RecipeEditDescriptor(Optional<String> nameEdit, List<IngredientRefEditDescriptor> ingredientEdits,
         List<StepEditDescriptor> stepEdits, List<TagEditDescriptor> tagEdits) {
 
         this.ingredientEdits = ingredientEdits;
@@ -30,7 +30,7 @@ public class RecipeEditDescriptor {
         this.nameEdit = nameEdit;
     }
 
-    public List<IngredientEditDescriptor> getIngredientEdits() {
+    public List<IngredientRefEditDescriptor> getIngredientEdits() {
         return this.ingredientEdits;
     }
 

--- a/src/main/java/chopchop/logic/parser/commands/DeleteCommandParser.java
+++ b/src/main/java/chopchop/logic/parser/commands/DeleteCommandParser.java
@@ -64,7 +64,7 @@ public class DeleteCommandParser {
         if (qtys.size() > 1) {
             return Result.error("Multiple quantities specified");
         } else if (qtys.size() == 1 && qtys.get(0).isEmpty()) {
-            return Result.error("Specified quantity cannot be emtpy");
+            return Result.error("Specified quantity cannot be empty");
         }
 
         return ItemReference.parse(name)

--- a/src/main/java/chopchop/logic/parser/commands/EditCommandParser.java
+++ b/src/main/java/chopchop/logic/parser/commands/EditCommandParser.java
@@ -55,7 +55,7 @@ public class EditCommandParser {
                     return parseEditIngredientCommand(target.snd().strip(), args);
 
                 default:
-                    return Result.error("Can only delete recipes or ingredients ('%s' invalid)", target.fst());
+                    return Result.error("Can only edit recipes or ingredients ('%s' invalid)", target.fst());
                 }
             });
     }

--- a/src/main/java/chopchop/logic/parser/commands/EditCommandParser.java
+++ b/src/main/java/chopchop/logic/parser/commands/EditCommandParser.java
@@ -9,7 +9,7 @@ import chopchop.model.attributes.Quantity;
 import chopchop.model.attributes.Tag;
 import chopchop.commons.util.Result;
 import chopchop.logic.edit.EditOperationType;
-import chopchop.logic.edit.IngredientEditDescriptor;
+import chopchop.logic.edit.IngredientRefEditDescriptor;
 import chopchop.logic.edit.RecipeEditDescriptor;
 import chopchop.logic.edit.StepEditDescriptor;
 import chopchop.logic.edit.TagEditDescriptor;
@@ -54,7 +54,7 @@ public class EditCommandParser {
                 Optional<String> editedName = Optional.empty();
                 var tagEdits = new ArrayList<Result<TagEditDescriptor>>();
                 var stepEdits = new ArrayList<Result<StepEditDescriptor>>();
-                var ingrEdits = new ArrayList<Result<IngredientEditDescriptor>>();
+                var ingrEdits = new ArrayList<Result<IngredientRefEditDescriptor>>();
 
                 for (int i = 0; i < args.getAllArguments().size(); i++) {
 
@@ -132,8 +132,8 @@ public class EditCommandParser {
 
 
 
-    private static Result<IngredientEditDescriptor> parseIngredientEdit(ArgName argName, String ingredientName,
-        Optional<Quantity> qty) {
+    private static Result<IngredientRefEditDescriptor> parseIngredientEdit(ArgName argName, String ingredientName,
+                                                                           Optional<Quantity> qty) {
 
         var components = argName.getComponents();
         if (components.isEmpty()) {
@@ -151,7 +151,7 @@ public class EditCommandParser {
         }
 
         return ensureNoArgsForDeleteAndGetOperationType("quantity", "ingredient", op, qty.isEmpty())
-            .map(kind -> new IngredientEditDescriptor(kind, ingredientName, qty));
+            .map(kind -> new IngredientRefEditDescriptor(kind, ingredientName, qty));
     }
 
 

--- a/src/main/java/chopchop/ui/CommandBox.java
+++ b/src/main/java/chopchop/ui/CommandBox.java
@@ -48,6 +48,7 @@ public class CommandBox extends UiPart<Region> {
                     this.commandTextField.positionCaret(command.length());
                 }
 
+                logic.resetCompletionState();
                 event.consume();
             } else if (event.getCode().equals(KeyCode.UP) && this.historyPointer > 0) {
                 this.historyPointer--;
@@ -55,6 +56,7 @@ public class CommandBox extends UiPart<Region> {
                 this.commandTextField.setText(command);
                 this.commandTextField.positionCaret(command.length());
 
+                logic.resetCompletionState();
                 event.consume();
             } else if (event.getCode().equals(KeyCode.TAB)) {
                 var text = this.commandTextField.getText();

--- a/src/test/java/chopchop/logic/autocomplete/AutoCompleterTest.java
+++ b/src/test/java/chopchop/logic/autocomplete/AutoCompleterTest.java
@@ -187,6 +187,12 @@ public class AutoCompleterTest {
         cases.put("edit recipe cake /tag:a",                "edit recipe cake /tag:add");
         cases.put("edit recipe cake /tag:d",                "edit recipe cake /tag:delete");
 
+        cases.put("edit i",                                 "edit ingredient");
+        cases.put("edit ingredient c",                      "edit ingredient Custard");
+        cases.put("edit ingredient cream /t",               "edit ingredient cream /tag:");
+        cases.put("edit ingredient cream /tag:a",           "edit ingredient cream /tag:add");
+        cases.put("edit ingredient cream /tag:d",           "edit ingredient cream /tag:delete");
+
         // no completions:
         cases.put("edit ingredient /f",                     "edit ingredient /f");
         cases.put("edit recipe /qty:e",                     "edit recipe /qty:e");

--- a/src/test/java/chopchop/logic/commands/EditIngredientCommandTest.java
+++ b/src/test/java/chopchop/logic/commands/EditIngredientCommandTest.java
@@ -1,0 +1,122 @@
+package chopchop.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import chopchop.commons.util.Pair;
+import chopchop.commons.util.Result;
+import chopchop.logic.history.HistoryManager;
+import chopchop.logic.parser.CommandParser;
+import chopchop.model.Model;
+import chopchop.model.attributes.Tag;
+import chopchop.testutil.StubbedModel;
+import org.junit.jupiter.api.Test;
+
+public class EditIngredientCommandTest {
+
+    private CommandResult runCommand(Model m, String str) {
+        var parser = new CommandParser();
+        var c = parser.parse(str);
+
+        if (c.isError()) {
+            assertEquals(1, c.getError());
+        }
+
+        assertTrue(c.hasValue());
+
+        return c.getValue().execute(m, new HistoryManager());
+    }
+
+    private CommandResult runCommand(String str) {
+        return runCommand(StubbedModel.filled(), str);
+    }
+
+    @Test
+    void test_nameEdits() {
+        {
+            var c = runCommand("edit ingredient owo");
+            assertTrue(c.isError());
+            assertEquals("Error: No ingredient named 'owo'", c.toString());
+        }
+
+        {
+            var c = runCommand("edit ingredient custard");
+            assertTrue(c.didSucceed());
+            assertEquals("No edits provided; ingredient 'Custard' was not modified", c.toString());
+        }
+    }
+
+    // @Test
+    void test_equals() {
+        var p = new CommandParser();
+        var c1 = p.parse("edit ingredient custard /tag:add tag 1");
+        var c2 = p.parse("edit ingredient custard /tag:add tag 1");
+        var c3 = p.parse("edit ingredient custard /tag:add tag 2");
+        var c4 = p.parse("edit ingredient cream /tag:add tag 1");
+
+        assertEquals(c1, c1);
+        assertEquals(c1, c2);
+
+        assertNotEquals(c1, Result.of("asdf"));
+        assertNotEquals(c1, c3);
+        assertNotEquals(c3, c4);
+    }
+
+    @Test
+    void test_undo() {
+        var m = StubbedModel.filled();
+        var p = new CommandParser();
+        p.parse("edit ingredient custard /tag:add tag 1")
+            .map(c -> Pair.of(c, c.execute(m, new HistoryManager())))
+            .map(cr -> {
+                assertTrue(cr.snd().didSucceed());
+                return cr;
+            })
+            .map(cr -> {
+                var erc = ((EditIngredientCommand) cr.fst());
+                erc.undo(m);
+                return cr;
+            });
+
+        var i = m.findIngredientWithName("custard");
+        assertTrue(i.isPresent());
+
+        var ingredient = i.get();
+        assertFalse(ingredient.getTags().contains(new Tag("tag 1")));
+    }
+
+    @Test
+    void test_tagEdits() {
+        var m = StubbedModel.filled();
+
+        {
+            var c = runCommand(m, "edit ingredient custard /tag:add tag 1");
+            assertTrue(c.didSucceed());
+
+            var i = m.findIngredientWithName("custard");
+            assertTrue(i.isPresent());
+
+            var ingredient = i.get();
+            assertTrue(ingredient.getTags().contains(new Tag("tag 1")));
+        }
+
+        {
+            var c = runCommand(m, "edit ingredient custard /tag:delete tag 1");
+            assertTrue(c.didSucceed());
+
+            var i = m.findIngredientWithName("custard");
+            assertTrue(i.isPresent());
+
+            var ingredient = i.get();
+            assertFalse(ingredient.getTags().contains(new Tag("tag 1")));
+        }
+
+        {
+            var c = runCommand(m, "edit ingredient custard /tag:delete owowowo");
+            assertTrue(c.isError());
+            assertEquals("Error: Ingredient 'Custard' does not have tag 'owowowo'", c.toString());
+        }
+    }
+}

--- a/src/test/java/chopchop/logic/commands/HelpCommandTest.java
+++ b/src/test/java/chopchop/logic/commands/HelpCommandTest.java
@@ -35,7 +35,7 @@ public class HelpCommandTest {
 
         cases.put(Pair.of("help", ""),
             "help: Shows a link to the user guide for ChopChop, and offers help for individual commands"
-                + " see the User Guide");
+                + " See the User Guide");
 
         test(cases);
     }
@@ -52,14 +52,14 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 AddRecipeCommand.getCommandString(),
                 AddRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("add", "ingredient"),
             String.format("%s: %s %s",
                 AddIngredientCommand.getCommandString(),
                 AddIngredientCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         test(cases);
@@ -77,14 +77,14 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 DeleteRecipeCommand.getCommandString(),
                 DeleteRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("delete", "ingredient"),
             String.format("%s: %s %s",
                 DeleteIngredientCommand.getCommandString(),
                 DeleteIngredientCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         test(cases);
@@ -104,7 +104,7 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 ViewRecipeCommand.getCommandString(),
                 ViewRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         test(cases);
@@ -123,7 +123,7 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 MakeRecipeCommand.getCommandString(),
                 MakeRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         test(cases);
@@ -135,13 +135,13 @@ public class HelpCommandTest {
         var cases = new HashMap<Pair<String, String>, String>();
 
         cases.put(Pair.of("edit", ""),
-            "edit: Edits an item; see 'edit recipe'");
+            "edit: Edits an item; see 'edit recipe' or 'edit ingredient'");
 
         cases.put(Pair.of("edit", "recipe"),
             String.format("%s: %s %s",
                 EditRecipeCommand.getCommandString(),
                 EditRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         test(cases);
@@ -159,14 +159,14 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 ListRecipeCommand.getCommandString(),
                 ListRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("list", "recipes"),
             String.format("%s: %s %s",
                 ListRecipeCommand.getCommandString(),
                 ListRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
 
@@ -174,14 +174,14 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 ListIngredientCommand.getCommandString(),
                 ListIngredientCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("list", "ingredients"),
             String.format("%s: %s %s",
                 ListIngredientCommand.getCommandString(),
                 ListIngredientCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         test(cases);
@@ -199,28 +199,28 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 FindRecipeCommand.getCommandString(),
                 FindRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("find", "recipes"),
             String.format("%s: %s %s",
                 FindRecipeCommand.getCommandString(),
                 FindRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("find", "ingredient"),
             String.format("%s: %s %s",
                 FindIngredientCommand.getCommandString(),
                 FindIngredientCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("find", "ingredients"),
             String.format("%s: %s %s",
                 FindIngredientCommand.getCommandString(),
                 FindIngredientCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
         test(cases);
     }
@@ -237,28 +237,28 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 FilterRecipeCommand.getCommandString(),
                 FilterRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("filter", "recipes"),
             String.format("%s: %s %s",
                 FilterRecipeCommand.getCommandString(),
                 FilterRecipeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("filter", "ingredient"),
             String.format("%s: %s %s",
                 FilterIngredientCommand.getCommandString(),
                 FilterIngredientCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("filter", "ingredients"),
             String.format("%s: %s %s",
                 FilterIngredientCommand.getCommandString(),
                 FilterIngredientCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
         test(cases);
     }
@@ -279,49 +279,49 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 StatsRecipeRecentCommand.getCommandString(),
                 StatsRecipeRecentCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("stats", "recipe top"),
             String.format("%s: %s %s",
                 StatsRecipeTopCommand.getCommandString(),
                 StatsRecipeTopCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("stats", "recipe made"),
             String.format("%s: %s %s",
                 StatsRecipeMadeCommand.getCommandString(),
                 StatsRecipeMadeCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("stats", "recipe clear"),
             String.format("%s: %s %s",
                 StatsRecipeClearCommand.getCommandString(),
                 StatsRecipeClearCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("stats", "ingredient recent"),
             String.format("%s: %s %s",
                 StatsIngredientRecentCommand.getCommandString(),
                 StatsIngredientRecentCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("stats", "ingredient used"),
             String.format("%s: %s %s",
                 StatsIngredientUsedCommand.getCommandString(),
                 StatsIngredientUsedCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("stats", "ingredient clear"),
             String.format("%s: %s %s",
                 StatsIngredientClearCommand.getCommandString(),
                 StatsIngredientClearCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
 
@@ -338,21 +338,21 @@ public class HelpCommandTest {
             String.format("%s: %s %s",
                 ClearCommand.getCommandString(),
                 ClearCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("undo", ""),
             String.format("%s: %s %s",
                 UndoCommand.getCommandString(),
                 UndoCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         cases.put(Pair.of("redo", ""),
             String.format("%s: %s %s",
                 RedoCommand.getCommandString(),
                 RedoCommand.getCommandHelp(),
-                "see the User Guide")
+                "See the User Guide")
         );
 
         test(cases);

--- a/src/test/java/chopchop/logic/edit/EditDescriptorTest.java
+++ b/src/test/java/chopchop/logic/edit/EditDescriptorTest.java
@@ -19,8 +19,8 @@ public class EditDescriptorTest {
     private static EditOperationType opEdit = EditOperationType.EDIT;
     private static EditOperationType opDelete = EditOperationType.DELETE;
 
-    private IngredientEditDescriptor ied(EditOperationType op, String name, Quantity q) {
-        return new IngredientEditDescriptor(op, name, Optional.ofNullable(q));
+    private IngredientRefEditDescriptor ied(EditOperationType op, String name, Quantity q) {
+        return new IngredientRefEditDescriptor(op, name, Optional.ofNullable(q));
     }
 
     private TagEditDescriptor ted(EditOperationType op, String name) {

--- a/src/test/java/chopchop/logic/parser/commands/EditCommandParserTest.java
+++ b/src/test/java/chopchop/logic/parser/commands/EditCommandParserTest.java
@@ -18,7 +18,7 @@ public class EditCommandParserTest {
         var parser = new CommandParser();
 
         cases.put("edit recipe",                                                        false);
-        cases.put("edit ingredient x",                                                  false);
+        cases.put("edit ingredient",                                                    false);
         cases.put("edit recipe x /ingredient",                                          false);
         cases.put("edit recipe x /ingredient:owo",                                      false);
         cases.put("edit recipe x /ingredient:owo:uwu",                                  false);
@@ -62,6 +62,9 @@ public class EditCommandParserTest {
         cases.put("edit recipe x /ingredient:add y /qty 1",                             true);
         cases.put("edit recipe x /ingredient:delete y",                                 true);
         cases.put("edit recipe x /ingredient:delete y /step:add z",                     true);
+
+        cases.put("edit ingredient x /tag:add y",                                       true);
+        cases.put("edit ingredient x /tag:delete y",                                    true);
 
 
         cases.forEach((k, v) -> {


### PR DESCRIPTION
Fixes #147. Slightly modifies behaviour to throw an error when trying to add tags that already exist (previously, they would show a successful editing of the recipe/ingredient).